### PR TITLE
Add login system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ This project provides a basic PHP-based inventory management system for pharmace
 - Track product quantity, price, expiration date, composition, packing, and category
 
 - Simple web interface using PHP and MySQL
+- Basic authentication system
 
 ## Getting Started
 
 1. Create a MySQL database (e.g., `inventory`).
 2. Import `db.sql` to create the required tables.
 
-3. (Optional) Import `sample_data.sql` to populate products with example entries.
+3. (Optional) Import `sample_data.sql` to populate products with example entries, including a default `admin` user (password `admin`).
 4. Update the database settings in `config.php`.
 5. Upload all files to your Hostinger PHP hosting account.
-6. Visit `index.php` in your browser to begin managing inventory.
+6. Visit `login.php` in your browser and log in with the credentials from the sample data.
 
 
 
@@ -32,6 +33,8 @@ This project provides a basic PHP-based inventory management system for pharmace
 - `edit_product.php` - Update existing products
 - `delete_product.php` - Delete a product
 - `style.css` - Basic styling
+- `login.php` - User login page
+- `logout.php` - End a session
 
 - `sample_data.sql` - Example products for testing
 

--- a/add_product.php
+++ b/add_product.php
@@ -1,5 +1,9 @@
 <?php
 require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name = $_POST['name'];
     $content = $_POST['content']; // Added from x93hgc-codex/create-inventory-management-software-for-pharma-manufacturer

--- a/config.php
+++ b/config.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 $host = 'localhost';
 $dbname = 'inventory';
 $user = 'root';

--- a/db.sql
+++ b/db.sql
@@ -9,3 +9,13 @@ CREATE TABLE IF NOT EXISTS products (
     expiration_date DATE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+);
+
+INSERT INTO users (username, password) VALUES
+('admin', '$2y$10$25PSEjYnmFbV9PveLuOwqu5NN7qthaDLTLsCTaArtPrZn3sKLBHQu');
+

--- a/delete_product.php
+++ b/delete_product.php
@@ -1,5 +1,9 @@
 <?php
 require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
 $id = (int)($_GET['id'] ?? 0);
 if ($id) {
     $stmt = $pdo->prepare('DELETE FROM products WHERE id=?');

--- a/edit_product.php
+++ b/edit_product.php
@@ -1,5 +1,9 @@
 <?php
 require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
 $id = (int)($_GET['id'] ?? 0);
 if (!$id) {
     header('Location: inventory.php');

--- a/index.php
+++ b/index.php
@@ -1,4 +1,9 @@
-<?php require 'config.php'; ?>
+<?php require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+?>
 <!DOCTYPE html>
 <html>
 <head>
@@ -7,6 +12,7 @@
 </head>
 <body>
     <h1>Pharma Inventory Management</h1>
+    <p>Logged in as <?php echo htmlspecialchars($_SESSION['username']); ?> | <a href="logout.php">Logout</a></p>
     <ul>
         <li><a href="inventory.php">View Inventory</a></li>
         <li><a href="add_product.php">Add Product</a></li>

--- a/inventory.php
+++ b/inventory.php
@@ -1,5 +1,9 @@
 <?php
 require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
 
 // Initialize search variable and prepare statement based on search query
 $search = $_GET['search'] ?? '';

--- a/login.php
+++ b/login.php
@@ -1,0 +1,42 @@
+<?php
+require 'config.php';
+// If already logged in, redirect to index
+if (isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE username=?');
+    $stmt->execute([$username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['username'] = $user['username'];
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Invalid credentials';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Login</h1>
+<?php if ($error): ?>
+<p style="color:red;"><?php echo htmlspecialchars($error); ?></p>
+<?php endif; ?>
+<form method="post">
+    <label>Username <input type="text" name="username" required></label>
+    <label>Password <input type="password" name="password" required></label>
+    <input type="submit" value="Login">
+</form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,7 @@
+<?php
+require 'config.php';
+session_unset();
+session_destroy();
+header('Location: login.php');
+exit;
+?>

--- a/sample_data.sql
+++ b/sample_data.sql
@@ -16,3 +16,7 @@ INSERT INTO products (name, content, packing, category, quantity, price, expirat
 ('GLIMCUZ-M GP 2', 'Glimepiride 2 mg, Metformin 500 mg Prolonged Release', '10 x 10 tablets (Alu-Alu packing)', 'Anti-Diabetic', 0, 0.00, NULL),
 ('ZEKMOL-650 Tablets', 'Paracetamol 650 mg', '10 x 10\'s', 'Analgesic and Antipyretic Tablets', 0, 0.00, NULL),
 ('ZIFLOZIN Tablets', 'Dapagliflozin 10 mg', '10 x 10\'s', 'Anti-Diabetic Tablets', 0, 0.00, NULL);
+
+INSERT INTO users (username, password) VALUES
+('admin', '$2y$10$25PSEjYnmFbV9PveLuOwqu5NN7qthaDLTLsCTaArtPrZn3sKLBHQu');
+


### PR DESCRIPTION
## Summary
- enable sessions in `config.php`
- create `login.php` and `logout.php`
- protect inventory pages using session checks
- add `users` table with example admin user
- document authentication in README

## Testing
- `pip install bcrypt` (to generate a password hash)


------
https://chatgpt.com/codex/tasks/task_e_68495a7cc024832aa4c485acb7f17ae1