### PR TITLE
Add numeric validation for quantity and price

### DIFF
--- a/add_product.php
+++ b/add_product.php
@@ -4,20 +4,29 @@ if (!isset($_SESSION['user_id'])) {
     header('Location: login.php');
     exit;
 }
+
+$error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name = $_POST['name'];
-    $content = $_POST['content']; // Added from x93hgc-codex/create-inventory-management-software-for-pharma-manufacturer
-    $packing = $_POST['packing']; // Added from x93hgc-codex/create-inventory-management-software-for-pharma-manufacturer
-    $category = $_POST['category']; // Added from x93hgc-codex/create-inventory-management-software-for-pharma-manufacturer
-    $quantity = (int)$_POST['quantity'];
-    $price = (float)$_POST['price'];
+    $content = $_POST['content'];
+    $packing = $_POST['packing'];
+    $category = $_POST['category'];
+    $quantity = $_POST['quantity'];
+    $price = $_POST['price'];
     $expiration = $_POST['expiration'];
 
-    // Merged INSERT statement to include new fields
-    $stmt = $pdo->prepare('INSERT INTO products (name, content, packing, category, quantity, price, expiration_date) VALUES (?, ?, ?, ?, ?, ?, ?)');
-    $stmt->execute([$name, $content, $packing, $category, $quantity, $price, $expiration]);
-    header('Location: inventory.php');
-    exit;
+    if (!is_numeric($quantity) || $quantity < 0 || $quantity > 1000000) {
+        $error = 'Quantity must be a number between 0 and 1,000,000';
+    } elseif (!is_numeric($price) || $price < 0 || $price > 100000) {
+        $error = 'Price must be a number between 0 and 100,000';
+    } else {
+        $quantity = (int)$quantity;
+        $price = (float)$price;
+        $stmt = $pdo->prepare('INSERT INTO products (name, content, packing, category, quantity, price, expiration_date) VALUES (?, ?, ?, ?, ?, ?, ?)');
+        $stmt->execute([$name, $content, $packing, $category, $quantity, $price, $expiration]);
+        header('Location: inventory.php');
+        exit;
+    }
 }
 ?>
 <!DOCTYPE html>
@@ -28,11 +37,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body>
 <h1>Add Product</h1>
+<?php if ($error): ?>
+<p style="color:red;"><?php echo htmlspecialchars($error); ?></p>
+<?php endif; ?>
 <form method="post">
-    <label>Name <input type="text" name="name" required></label>
-    <label>Content <textarea name="content" rows="3" cols="40"></textarea></label> <label>Packing <input type="text" name="packing"></label> <label>Category <input type="text" name="category"></label> <label>Quantity <input type="number" name="quantity" required></label>
-    <label>Price <input type="number" step="0.01" name="price" required></label>
-    <label>Expiration Date <input type="date" name="expiration"></label>
+    <label>Name <input type="text" name="name" value="<?php echo htmlspecialchars($_POST['name'] ?? ''); ?>" required></label>
+    <label>Content <textarea name="content" rows="3" cols="40"><?php echo htmlspecialchars($_POST['content'] ?? ''); ?></textarea></label> <label>Packing <input type="text" name="packing" value="<?php echo htmlspecialchars($_POST['packing'] ?? ''); ?>"></label> <label>Category <input type="text" name="category" value="<?php echo htmlspecialchars($_POST['category'] ?? ''); ?>"></label> <label>Quantity <input type="number" name="quantity" value="<?php echo htmlspecialchars($_POST['quantity'] ?? ''); ?>" required></label>
+    <label>Price <input type="number" step="0.01" name="price" value="<?php echo htmlspecialchars($_POST['price'] ?? ''); ?>" required></label>
+    <label>Expiration Date <input type="date" name="expiration" value="<?php echo htmlspecialchars($_POST['expiration'] ?? ''); ?>"></label>
     <input type="submit" value="Add">
 </form>
 <p><a href="inventory.php">Back to Inventory</a></p>


### PR DESCRIPTION
## Summary
- validate quantity and price in product forms
- show validation errors instead of redirecting
- keep form values and escape all output

## Testing
- `php -l add_product.php`
- `php -l edit_product.php`


------
https://chatgpt.com/codex/tasks/task_e_68495c925e7c832ab5793934fb2330b0