### PR TITLE
Add role-based mobile dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project provides a lightweight inventory management system for pharmaceutic
 - Track quantity, price, expiration date, composition, packing and category
 - Web interface secured by a simple username/password login
 - REST API for integrations
+- Export products to CSV via `/export`
 - Mobile interface implemented as a PWA
 
 ## Getting Started
@@ -22,8 +23,16 @@ This project provides a lightweight inventory management system for pharmaceutic
    ```bash
    python app.py
    ```
-4. Visit `http://localhost:5000/login` to sign in (default admin/admin123).
-5. Access the mobile interface at `http://localhost:5000/mobile`.
+4. Visit `http://localhost:5000/login` to sign in. Sample accounts:
+   - Manufacturer admin: `admin` / `admin123`
+   - Clearing agent: `cfa` / `cfa123`
+   - Super stockists: `stockist1`..`stockist20` with passwords `stock1`..`stock20`
+5. After login you are redirected to the appropriate dashboard:
+   - Manufacturer dashboard at `/mobile/admin`
+   - CFA dashboard at `/mobile/cfa`
+   - Stockist dashboard at `/mobile/stockist/<name>`
+   - Generic PWA entry point available at `/mobile` which forwards to the
+     correct dashboard based on the logged in user
 
 The database is automatically created on first run. You can reset it anytime by visiting `/init`.
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
-from flask import Flask, render_template, request, redirect, url_for, session, jsonify
+from flask import Flask, render_template, request, redirect, url_for, session, jsonify, Response
 from flask import g
+import csv
+import io
 import sqlite3
 import os
 
@@ -7,14 +9,17 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = 'change-this-key'
 app.config['DATABASE'] = os.path.join(app.root_path, 'inventory.db')
 
-ADMIN_USERNAME = 'admin'
-ADMIN_PASSWORD = 'admin123'
+from passlib.hash import bcrypt
 
 
 def _init_db(db):
-    """Create database tables from schema.sql."""
+    """Create database tables and load sample data."""
     with open(os.path.join(app.root_path, 'schema.sql'), 'r') as f:
         db.executescript(f.read())
+    sample_path = os.path.join(app.root_path, 'sample_data.sql')
+    if os.path.exists(sample_path):
+        with open(sample_path, 'r') as sf:
+            db.executescript(sf.read())
     db.commit()
 
 
@@ -57,32 +62,14 @@ def init_route():
 def index():
     if 'username' not in session:
         return redirect(url_for('login'))
+    role = session.get('role')
+    if role == 'manufacturer':
+        return redirect(url_for('mobile_admin'))
+    elif role == 'cfa':
+        return redirect(url_for('mobile_cfa'))
+    elif role == 'stockist':
+        return redirect(url_for('mobile_stockist', name=session.get('username')))
     return render_template('index.html')
-
-
-@app.route('/mobile')
-def mobile():
-    return render_template('mobile.html')
-
-
-@app.route('/login', methods=['GET', 'POST'])
-def login():
-    error = None
-    if request.method == 'POST':
-        username = request.form['username']
-        password = request.form['password']
-        if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
-            session['username'] = username
-            return redirect(url_for('inventory'))
-        else:
-            error = 'Invalid credentials'
-    return render_template('login.html', error=error)
-
-
-@app.route('/logout')
-def logout():
-    session.pop('username', None)
-    return redirect(url_for('login'))
 
 
 def login_required(fn):
@@ -93,6 +80,77 @@ def login_required(fn):
             return redirect(url_for('login'))
         return fn(*args, **kwargs)
     return wrapper
+
+
+@app.route('/mobile')
+@login_required
+def mobile_redirect():
+    role = session.get('role')
+    if role == 'manufacturer':
+        return redirect(url_for('mobile_admin'))
+    elif role == 'cfa':
+        return redirect(url_for('mobile_cfa'))
+    elif role == 'stockist':
+        return redirect(url_for('mobile_stockist', name=session.get('username')))
+    return 'Forbidden', 403
+
+
+
+
+@app.route('/mobile/admin')
+@login_required
+def mobile_admin():
+    if session.get('role') != 'manufacturer':
+        return 'Forbidden', 403
+    return render_template('mobile_admin.html')
+
+
+@app.route('/mobile/cfa')
+@login_required
+def mobile_cfa():
+    role = session.get('role')
+    if role not in ('manufacturer', 'cfa'):
+        return 'Forbidden', 403
+    return render_template('mobile_cfa.html')
+
+
+@app.route('/mobile/stockist/<name>')
+@login_required
+def mobile_stockist(name):
+    role = session.get('role')
+    if role == 'stockist' and name != session.get('username'):
+        return 'Forbidden', 403
+    return render_template('mobile_stockist.html', stockist=name)
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        db = get_db()
+        cur = db.execute('SELECT password, role FROM users WHERE username=?', (username,))
+        row = cur.fetchone()
+        if row and bcrypt.verify(password, row['password']):
+            session['username'] = username
+            session['role'] = row['role']
+            if row['role'] == 'manufacturer':
+                return redirect(url_for('mobile_admin'))
+            elif row['role'] == 'cfa':
+                return redirect(url_for('mobile_cfa'))
+            elif row['role'] == 'stockist':
+                return redirect(url_for('mobile_stockist', name=username))
+            return redirect(url_for('inventory'))
+        error = 'Invalid credentials'
+    return render_template('login.html', error=error)
+
+
+@app.route('/logout')
+def logout():
+    session.pop('username', None)
+    session.pop('role', None)
+    return redirect(url_for('login'))
 
 
 @app.route('/inventory')
@@ -225,6 +283,22 @@ def api_product(pid):
         db.execute("DELETE FROM products WHERE id=?", (pid,))
         db.commit()
         return jsonify({'deleted': True})
+
+
+@app.route('/export')
+@login_required
+def export_csv():
+    """Download all products as a CSV file."""
+    db = get_db()
+    cur = db.execute('SELECT * FROM products')
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([d[0] for d in cur.description])
+    for row in cur.fetchall():
+        writer.writerow(row)
+    resp = Response(output.getvalue(), mimetype='text/csv')
+    resp.headers['Content-Disposition'] = 'attachment; filename=products.csv'
+    return resp
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+passlib

--- a/sample_data.sql
+++ b/sample_data.sql
@@ -14,8 +14,29 @@ INSERT INTO products (name, content, packing, category, quantity, price, expirat
 ('ZEKCLAV-DS', 'Amoxycillin, Pot. Clavulanate 28.5 mg', '30 ml syrup bottle (with sterile water for mixing)', 'Antibiotic', 0, 0.00, NULL),
 ('GLIMCUZ-M GP 1', 'Glimepiride 1 mg, Metformin 500 mg Prolonged Release', '10 x 10 tablets (Alu-Alu packing)', 'Anti-Diabetic', 0, 0.00, NULL),
 ('GLIMCUZ-M GP 2', 'Glimepiride 2 mg, Metformin 500 mg Prolonged Release', '10 x 10 tablets (Alu-Alu packing)', 'Anti-Diabetic', 0, 0.00, NULL),
-('ZEKMOL-650 Tablets', 'Paracetamol 650 mg', '10 x 10\'s', 'Analgesic and Antipyretic Tablets', 0, 0.00, NULL),
-('ZIFLOZIN Tablets', 'Dapagliflozin 10 mg', '10 x 10\'s', 'Anti-Diabetic Tablets', 0, 0.00, NULL);
+('ZEKMOL-650 Tablets', 'Paracetamol 650 mg', '10 x 10''s', 'Analgesic and Antipyretic Tablets', 0, 0.00, NULL),
+('ZIFLOZIN Tablets', 'Dapagliflozin 10 mg', '10 x 10''s', 'Anti-Diabetic Tablets', 0, 0.00, NULL);
 
-INSERT INTO users (username, password) VALUES
-('admin', '$2y$10$25PSEjYnmFbV9PveLuOwqu5NN7qthaDLTLsCTaArtPrZn3sKLBHQu');
+INSERT INTO users (username, password, role) VALUES
+('admin', '$2b$12$AoRAkNc/7b/eNXUAyCl.t.Su5SH6j.SpJwvFJ5rqqyFH5KiUhTLG6', 'manufacturer'),
+('cfa', '$2b$12$qBHSrV7yQVXXzZgIcSKDj.dS35K.wNxR2OiBetCx1YFYEiWn.cyWS', 'cfa'),
+('stockist1', '$2b$12$fgT3oXNEYrV9pfMx0sqqBe8wQWZ8Gky256pVCAWNoW7qtFylCxkXG', 'stockist'),
+('stockist2', '$2b$12$THeIZ5q/IN3mMsqT/ZfgT.J7AQiL/zCB/ayhmUobk0PugvEQ278la', 'stockist'),
+('stockist3', '$2b$12$kSGEM60kUQBSotg7hhhKWO.Yx/pCO3AeSilnXFoZRRDKXsS6rb7wq', 'stockist'),
+('stockist4', '$2b$12$KV7Kc3jMz0I9HcfiLgO9feb2dJ2Uv6/qvrB.4vcAPMPLvH7mtMucG', 'stockist'),
+('stockist5', '$2b$12$aVjCo.6AeErl0VPthRrtVuCBcNcVuBIMOYZ36hsxTAgk0fxg.cdAW', 'stockist'),
+('stockist6', '$2b$12$tY0yvianDzuALhlOfsBgueyETihqJFeVpNh9Gk/i31N.6qKzqjOCu', 'stockist'),
+('stockist7', '$2b$12$SKtZ.R.zeRUrWgLGTGVZser9iBnseiTZyoqyNoMafSjBCCXU0iRQi', 'stockist'),
+('stockist8', '$2b$12$BNZ2wwkw1GxLMrDM74sqbu5ytGAEthOtvsFhcI.WhNJOzEGpGCLxW', 'stockist'),
+('stockist9', '$2b$12$MZgYjqrFnXQJfmJYq0MH0OqLTcXhSwIFIuoIkPEmsQtQ7I/rudgV6', 'stockist'),
+('stockist10', '$2b$12$jxy5iqEDZGBguyuixRhg3.Dp/cJRMgZk9kLtFs4lJanncfihm8bMW', 'stockist'),
+('stockist11', '$2b$12$ttkfDgBvkt4LOfReeUwc9.RtlrTtd/oW5j5UQ82tMpzHUvSCpcX3u', 'stockist'),
+('stockist12', '$2b$12$rmWwOWd5W7G24G8KYpnHWOnIiOoJPdeGiqFRO7s58sVVZUTqBVBv2', 'stockist'),
+('stockist13', '$2b$12$XK6/GZ9UwUvlajvj.QdAUu0oSHIC9zcSO.f3vTkM90VzU6pUxr/gW', 'stockist'),
+('stockist14', '$2b$12$dwYAcDGEgGh4qJvJZz5rOeQLYPgS4aJSRtbdfmbdIH4G8eDQQy33K', 'stockist'),
+('stockist15', '$2b$12$IrXdCVAST6QJ7lpD2P5yguSyRH/jxZJnKek1F23Hc6CfBc7FtctDm', 'stockist'),
+('stockist16', '$2b$12$w3eitsw55Hij4VYwtV/QiuA.XGJUn7iQzeeEnvvEZFeq2lpR.CLF2', 'stockist'),
+('stockist17', '$2b$12$sXtUIHSq2sdpd9LAOeKZkuEuq4ngSc4GwGNr0Ng/cXcQSVf0AdrLG', 'stockist'),
+('stockist18', '$2b$12$vnYM7fhZDn5sDrbiBbnpxuS4h03JMHDzi2mBebAPIWLlVg4Ni0pCS', 'stockist'),
+('stockist19', '$2b$12$UkCL0I06pIaZnom50OO./OQWVITWp09qciCyCl/K1ctrbm9HFwi.S', 'stockist'),
+('stockist20', '$2b$12$Hedkfn4FgXmwOTJV0kAKeu1.wEu3CyS1qiqIfkUT9Vd9CpgUWXKu6', 'stockist');

--- a/schema.sql
+++ b/schema.sql
@@ -9,3 +9,10 @@ CREATE TABLE IF NOT EXISTS products (
     expiration_date TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'manufacturer'
+);

--- a/static/mobile.css
+++ b/static/mobile.css
@@ -1,0 +1,53 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    background: #f5f5f5;
+}
+header {
+    background: #317EFB;
+    color: white;
+    padding: 1rem;
+    text-align: center;
+}
+#list {
+    padding: 1rem;
+}
+.product {
+    background: white;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.product button {
+    margin-right: 0.5rem;
+}
+#product-form {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    background: white;
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
+    padding: 1rem;
+    display: none;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+#product-form label {
+    display: block;
+    margin-bottom: 0.5rem;
+}
+#show-form {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: #317EFB;
+    color: white;
+    border: none;
+    font-size: 2rem;
+    line-height: 0;
+}

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -1,6 +1,17 @@
 // Base URL for the Flask REST API
 const API = '/api/products';
 
+function showForm() {
+    document.getElementById('product-form').style.display = 'block';
+    document.getElementById('show-form').style.display = 'none';
+    window.scrollTo(0, document.body.scrollHeight);
+}
+
+function hideForm() {
+    document.getElementById('product-form').style.display = 'none';
+    document.getElementById('show-form').style.display = 'block';
+}
+
 function loadProducts() {
     fetch(API)
         .then(r => r.json())
@@ -27,7 +38,10 @@ function renderProducts(data) {
 function editProduct(id) {
     fetch(`${API}/${id}`)
         .then(r => r.json())
-        .then(fillForm);
+        .then(p => {
+            fillForm(p);
+            showForm();
+        });
 }
 
 function deleteProduct(id) {
@@ -52,7 +66,13 @@ function resetForm() {
     document.getElementById('form-title').textContent = 'Add Product';
     document.getElementById('product-form').reset();
     document.getElementById('prod-id').value = '';
+    hideForm();
 }
+
+document.getElementById('show-form').addEventListener('click', () => {
+    resetForm();
+    showForm();
+});
 
 document.getElementById('cancel').addEventListener('click', resetForm);
 
@@ -81,3 +101,4 @@ document.getElementById('product-form').addEventListener('submit', function(e) {
 });
 
 loadProducts();
+hideForm();

--- a/static/mobile_view.js
+++ b/static/mobile_view.js
@@ -1,0 +1,22 @@
+const API = '/api/products';
+
+function loadProducts() {
+    fetch(API)
+        .then(r => r.json())
+        .then(data => {
+            const list = document.getElementById('list');
+            list.innerHTML = '';
+            data.forEach(p => {
+                const div = document.createElement('div');
+                div.className = 'product';
+                div.innerHTML = `<strong>${p.name}</strong>
+                    <p>${p.content}</p>
+                    <p>${p.packing} - ${p.category}</p>
+                    <p>Qty: ${p.quantity} Price: ${p.price}</p>
+                    <p>Expiration: ${p.expiration_date || ''}</p>`;
+                list.appendChild(div);
+            });
+        });
+}
+
+loadProducts();

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -7,7 +7,11 @@
     <input type="submit" value="Search">
     <a href="{{ url_for('inventory') }}">Clear</a>
 </form>
-<p><a href="{{ url_for('add') }}">Add Product</a> | <a href="{{ url_for('index') }}">Home</a></p>
+<p>
+    <a href="{{ url_for('add') }}">Add Product</a> |
+    <a href="{{ url_for('index') }}">Home</a> |
+    <a href="{{ url_for('export_csv') }}">Export CSV</a>
+</p>
 <table>
     <tr>
         <th>ID</th>

--- a/templates/mobile_admin.html
+++ b/templates/mobile_admin.html
@@ -2,18 +2,15 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Inventory Mobile</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <title>Manufacturer Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='mobile.css') }}">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
     <meta name="theme-color" content="#317EFB">
-    <style>
-        body { font-size: 16px; }
-        .product { border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; }
-        button { margin-left: 5px; }
-    </style>
 </head>
 <body>
-    <h1>Inventory</h1>
+    <header>
+        <h1>Manufacturer</h1>
+    </header>
     <div id="list"></div>
 
     <h2 id="form-title">Add Product</h2>
@@ -29,6 +26,7 @@
         <button type="submit">Save</button>
         <button type="button" id="cancel">Cancel</button>
     </form>
+    <button id="show-form">+</button>
     <script src="{{ url_for('static', filename='mobile.js') }}"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/templates/mobile_cfa.html
+++ b/templates/mobile_cfa.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CFA Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='mobile.css') }}">
+</head>
+<body>
+    <header>
+        <h1>CFA</h1>
+    </header>
+    <div id="list"></div>
+    <script src="{{ url_for('static', filename='mobile_view.js') }}"></script>
+</body>
+</html>

--- a/templates/mobile_stockist.html
+++ b/templates/mobile_stockist.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ stockist }} Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='mobile.css') }}">
+</head>
+<body>
+    <header>
+        <h1>{{ stockist }}</h1>
+    </header>
+    <div id="list"></div>
+    <script src="{{ url_for('static', filename='mobile_view.js') }}"></script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+import json
+import sqlite3
+import unittest
+
+from app import app, _init_db
+
+class APITestCase(unittest.TestCase):
+    def setUp(self):
+        self.db_fd, self.db_path = tempfile.mkstemp()
+        app.config['DATABASE'] = self.db_path
+        app.config['TESTING'] = True
+        with app.app_context():
+            db = sqlite3.connect(self.db_path)
+            _init_db(db)
+            db.close()
+        self.client = app.test_client()
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(self.db_path)
+
+    def test_list_products(self):
+        rv = self.client.get('/api/products')
+        self.assertEqual(rv.status_code, 200)
+        data = rv.get_json()
+        self.assertTrue(len(data) > 0)
+
+    def test_crud_flow(self):
+        # create
+        new_data = {
+            'name': 'Test',
+            'content': '',
+            'packing': '',
+            'category': '',
+            'quantity': 1,
+            'price': 1.0,
+            'expiration_date': None
+        }
+        rv = self.client.post('/api/products', json=new_data)
+        self.assertEqual(rv.status_code, 200)
+        pid = rv.get_json()['id']
+        # retrieve
+        rv = self.client.get(f'/api/products/{pid}')
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(rv.get_json()['name'], 'Test')
+        # update
+        rv = self.client.put(f'/api/products/{pid}', json={'name': 'Updated'})
+        self.assertEqual(rv.status_code, 200)
+        rv = self.client.get(f'/api/products/{pid}')
+        self.assertEqual(rv.get_json()['name'], 'Updated')
+        # delete
+        rv = self.client.delete(f'/api/products/{pid}')
+        self.assertEqual(rv.status_code, 200)
+        rv = self.client.get(f'/api/products/{pid}')
+        self.assertEqual(rv.get_json(), {})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a role field to users table
- seed manufacturer, CFA and 20 stockist users
- implement role-aware login and dashboard redirects
- add new mobile views for manufacturer, CFA and stockists
- document credentials and dashboard URLs
- add `/mobile` endpoint that forwards to the proper dashboard

## Testing
- `python -m py_compile app.py tests/test_api.py`
- `python -m unittest tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6849703a7b84832aab97e1e27a03705a